### PR TITLE
Refactor header bar #11

### DIFF
--- a/src/components/ui/navbar/HeaderBar/index.tsx
+++ b/src/components/ui/navbar/HeaderBar/index.tsx
@@ -14,7 +14,7 @@ import { useAppDispatch, useItemSlice } from 'store/hooks/index';
 
 function HeaderBar() {
   const navigate = useNavigate();
-  const pathname: any = useLocation().pathname;
+  const pathname: string = useLocation().pathname;
 
   const dispatch = useAppDispatch();
   const { isDetailPage } = useItemSlice();

--- a/src/components/ui/navbar/HeaderBar/index.tsx
+++ b/src/components/ui/navbar/HeaderBar/index.tsx
@@ -21,20 +21,18 @@ function HeaderBar() {
 
   return (
     <S.HeaderBar>
-      {'/' === pathname ? (
-        <S.HeaderLeft onClick={() => navigate('/')}>
-          <LogoIcon />
-        </S.HeaderLeft>
-      ) : (
-        <>
-          <S.HeaderLeft
-            onClick={() => navigate(-1)}
-            style={pathname === '/' ? { marginLeft: '2rem' } : { marginLeft: '2.5rem' }}
-          >
+      <>
+        {'/' === pathname ? (
+          <S.HeaderLeft onClick={() => navigate('/')}>
+            <LogoIcon />
+          </S.HeaderLeft>
+        ) : (
+          <S.HeaderLeft onClick={() => navigate(-1)}>
             <ArrowLeftIcon />
           </S.HeaderLeft>
-
-          {!isDetailPage && (
+        )}
+        {'/items' === pathname ? (
+          !isDetailPage && (
             <S.HeaderCenter>
               <span
                 className="Catagory"
@@ -43,14 +41,14 @@ function HeaderBar() {
                 }}
               >
                 ITEMS
-                {/* 개발편의상 잠시 하드 코딩해놓았습니다! */}
-                {/* {pageName[pathname]} */}
               </span>
               <CategoryArrowBottomIcon />
             </S.HeaderCenter>
-          )}
-        </>
-      )}
+          )
+        ) : (
+          <S.HeaderCenter>{pageName[pathname]}</S.HeaderCenter>
+        )}
+      </>
       <S.HeaderUl>
         <S.HeaderLi>
           <SearchIcon />

--- a/src/components/ui/navbar/HeaderBar/style.ts
+++ b/src/components/ui/navbar/HeaderBar/style.ts
@@ -1,9 +1,5 @@
 import styled from 'styled-components';
 
-interface Props {
-  pathName: any;
-}
-
 export const HeaderBar = styled.nav`
   width: 100%;
   height: 5rem;
@@ -17,8 +13,10 @@ export const HeaderBar = styled.nav`
 export const HeaderLeft = styled.div`
   width: 13rem;
   height: 2.35rem;
-  margin-left: 1.5rem;
   cursor: pointer;
+  & svg {
+    margin-left: 2rem;
+  }
 `;
 
 export const HeaderCenter = styled.div`

--- a/src/components/ui/navbar/HeaderBar/style.ts
+++ b/src/components/ui/navbar/HeaderBar/style.ts
@@ -11,17 +11,18 @@ export const HeaderBar = styled.nav`
 `;
 
 export const HeaderLeft = styled.div`
-  width: 13rem;
   height: 2.35rem;
-  cursor: pointer;
   & svg {
+    cursor: pointer;
+    border-color: red;
     margin-left: 2rem;
   }
 `;
 
 export const HeaderCenter = styled.div`
+  width: auto;
   text-align: center;
-  position: absolute;
+  position: relative;
   left: 0;
   right: 0;
   color: #26252a;
@@ -29,7 +30,13 @@ export const HeaderCenter = styled.div`
   font-size: 2rem;
   font-weight: 600;
   .Catagory {
-    margin-right: 10px;
+    cursor: pointer;
+  }
+  & svg {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    margin: auto 10px;
   }
 `;
 

--- a/src/components/ui/navbar/HeaderBar/style.ts
+++ b/src/components/ui/navbar/HeaderBar/style.ts
@@ -14,7 +14,6 @@ export const HeaderLeft = styled.div`
   height: 2.35rem;
   & svg {
     cursor: pointer;
-    border-color: red;
     margin-left: 2rem;
   }
 `;


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- 'x'를 이용하여 이 PR에 적용되는 항목을 확인해 주세요. -->

- [x] 버그를 수정했어요.
- [ ] 새로운 기능을 추가했어요.
- [ ] 코드 스타일 업데이트를 했어요(포맷팅, 지역변수)
- [x] 리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [ ] 환경설정을 변경했어요.
- [ ] 문서 내용을 변경했어요.
- [ ] 기타 사항을 설명해 주세요.

## Related Issues

<!--#을 눌러 이슈와 연결해 주세요-->
#11 
## What does this PR do?

<!--무엇을 하셨나요?-->

- [x] items페이제를 제외한 각 페이지의 위치가 뜨도록 수정 (HeaderCenter)
- [x] HeaderCenter 스타일 수정으로 아이콘 pointer 되도록 수정
- [x] HeaderLeft의 margin-left 수정

## Other information

<!--참고한 자료, 추가적인 사항, 기타 의견-->
### HeaderCenter의 스타일 
```css
& svg {
    position: absolute;
    top: 0;
    bottom: 0;
    margin: auto 10px;
  }
```
부분에서 svg에 `position: absolute;` 속성은
아이콘 부분을 제외한 텍스트가 가운데 정렬되도록 하기위해 설정했습니다.
- 적용 전
![스크린샷 2022-09-27 오후 7 52 59](https://user-images.githubusercontent.com/99096272/192507208-c740a0e3-34d6-4681-9292-86bee0ca4cb5.png)
- 적용 후
![스크린샷 2022-09-27 오후 7 53 58](https://user-images.githubusercontent.com/99096272/192507358-624f936c-9075-452a-9893-e0e2105ecf06.png)
